### PR TITLE
Allow all Inputs' text to be cleared with CTRL+D

### DIFF
--- a/tool/ui.re
+++ b/tool/ui.re
@@ -228,6 +228,8 @@ impl Input {
             self.input = self.input.slice(0, -1);
         } else if key.to_small() == KEY_V.to_small() && (LCTRL_PRESSED || RCTRL_PRESSED) {
             self.input = f"{self.input}{Tas::get_clipboard()}";
+        } else if key.to_small() == KEY_D.to_small() && (LCTRL_PRESSED || RCTRL_PRESSED){
+            self.input = "";
         } else {
             match chr {
                 Option::Some(s) => {


### PR DESCRIPTION
Fixes #142.