### PR TITLE
Add ability to open maps folder

### DIFF
--- a/rtil/Cargo.lock
+++ b/rtil/Cargo.lock
@@ -150,6 +150,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "bstr"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6798148dccfbff0fae41c7574d2fa8f1ef3492fba0face179de5d8d447d67b05"
+dependencies = [
+ "memchr",
+ "regex-automata",
+ "serde",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1085,6 +1096,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "normpath"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec60c60a693226186f5d6edf073232bfb6464ed97eb22cf3b01c1e8198fd97f5"
+dependencies = [
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "num-integer"
 version = "0.1.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1183,6 +1203,17 @@ name = "opaque-debug"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c"
+
+[[package]]
+name = "opener"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c62dcb6174f9cb326eac248f07e955d5d559c272730b6c03e396b443b562788"
+dependencies = [
+ "bstr",
+ "normpath",
+ "winapi 0.3.9",
+]
 
 [[package]]
 name = "openssl"
@@ -1654,6 +1685,7 @@ dependencies = [
  "libc",
  "memoffset 0.6.5",
  "once_cell",
+ "opener",
  "protocol",
  "rebo",
  "rtil_derive",
@@ -1676,6 +1708,12 @@ dependencies = [
  "memchr",
  "regex-syntax",
 ]
+
+[[package]]
+name = "regex-automata"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59b23e92ee4318893fa3fe3e6fb365258efbfe6ac6ab30f090cdcbb7aa37efa9"
 
 [[package]]
 name = "regex-syntax"
@@ -2491,6 +2529,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc 0.48.5",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2501,6 +2569,12 @@ name = "windows_aarch64_msvc"
 version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd761fd3eb9ab8cc1ed81e56e567f02dd82c4c837e48ac3b2181b9ffc5060807"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -2515,6 +2589,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cab0cf703a96bab2dc0c02c0fa748491294bf9b7feb27e1f4f96340f208ada0e"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
+
+[[package]]
 name = "windows_i686_msvc"
 version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2525,6 +2605,12 @@ name = "windows_i686_msvc"
 version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8cfdbe89cc9ad7ce618ba34abc34bbb6c36d99e96cae2245b7943cd75ee773d0"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -2539,6 +2625,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4dd9b0c0e9ece7bb22e84d70d01b71c6d6248b81a3c60d11869451b4cb24784"
 
 [[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2549,6 +2647,12 @@ name = "windows_x86_64_msvc"
 version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff1e4aa646495048ec7f3ffddc411e1d829c026a2ec62b39da15c1055e406eaa"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "ws2_32-sys"

--- a/rtil/Cargo.toml
+++ b/rtil/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["oberien <jaro.fietz@gmx.de>"]
 edition = "2021"
 
 [dependencies]
+opener = "0.6.1"
 protocol = { path = "../protocol" }
 once_cell = "1.9.0"
 byteorder = "1.4.3"

--- a/rtil/src/threads/ue/rebo/rebo_init.rs
+++ b/rtil/src/threads/ue/rebo/rebo_init.rs
@@ -1279,6 +1279,6 @@ fn exit_water() {
 #[rebo::function("Tas::open_maps_folder")]
 fn open_maps_folder() {
     if let Err(err) = opener::open(&map_path()) {
-        log!("An error occurred: {}", err);
+        log!("Error opening maps folder in file manager: {}", err);
     }
 }

--- a/rtil/src/threads/ue/rebo/rebo_init.rs
+++ b/rtil/src/threads/ue/rebo/rebo_init.rs
@@ -18,6 +18,7 @@ use super::STATE;
 use serde::{Serialize, Deserialize};
 use crate::threads::ue::{Suspend, UeEvent, rebo::YIELDER};
 use crate::native::{ElementIndex, ElementType, ue::FRotator};
+use opener;
 
 pub fn create_config(rebo_stream_tx: Sender<ReboToStream>) -> ReboConfig {
     let mut cfg = ReboConfig::new()
@@ -111,6 +112,7 @@ pub fn create_config(rebo_stream_tx: Sender<ReboToStream>) -> ReboConfig {
         .add_function(enable_collision)
         .add_function(disable_collision)
         .add_function(exit_water)
+        .add_function(open_maps_folder)
         .add_external_type(Location)
         .add_external_type(Rotation)
         .add_external_type(Velocity)
@@ -1273,4 +1275,10 @@ fn disable_collision() {
 #[rebo::function("Tas::exit_water")]
 fn exit_water() {
     AMyCharacter::exit_water();
+}
+#[rebo::function("Tas::open_maps_folder")]
+fn open_maps_folder() {
+    if let Err(err) = opener::open(map_path().as_os_str().to_str().unwrap()) {
+        log!("An error occurred: {}", err);
+    }
 }

--- a/rtil/src/threads/ue/rebo/rebo_init.rs
+++ b/rtil/src/threads/ue/rebo/rebo_init.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::ffi::OsStr;
 use std::fs::File;
 use std::io::{ErrorKind, Write};
 use std::ops::Deref;
@@ -1278,7 +1279,7 @@ fn exit_water() {
 }
 #[rebo::function("Tas::open_maps_folder")]
 fn open_maps_folder() {
-    if let Err(err) = opener::open(map_path().as_os_str().to_str().unwrap()) {
+    if let Err(err) = opener::open::<&OsStr>(map_path().as_path().as_ref()) {
         log!("An error occurred: {}", err);
     }
 }

--- a/rtil/src/threads/ue/rebo/rebo_init.rs
+++ b/rtil/src/threads/ue/rebo/rebo_init.rs
@@ -1,5 +1,4 @@
 use std::collections::HashMap;
-use std::ffi::OsStr;
 use std::fs::File;
 use std::io::{ErrorKind, Write};
 use std::ops::Deref;

--- a/rtil/src/threads/ue/rebo/rebo_init.rs
+++ b/rtil/src/threads/ue/rebo/rebo_init.rs
@@ -1279,7 +1279,7 @@ fn exit_water() {
 }
 #[rebo::function("Tas::open_maps_folder")]
 fn open_maps_folder() {
-    if let Err(err) = opener::open::<&OsStr>(map_path().as_path().as_ref()) {
+    if let Err(err) = opener::open(&map_path()) {
         log!("An error occurred: {}", err);
     }
 }

--- a/tool/mapeditor.re
+++ b/tool/mapeditor.re
@@ -138,6 +138,10 @@ fn create_map_editor_menu() -> Ui {
         },
     }));
     list.push(UiElement::Button(UiButton {
+       label: Text { text: "Open Maps Folder" },
+       onclick: fn(label: Text) { Tas::open_maps_folder(); },
+    }));
+    list.push(UiElement::Button(UiButton {
        label: Text { text: "Back" },
        onclick: fn(label: Text) { leave_ui() },
     }));


### PR DESCRIPTION
Resolves #278

This may not behave correctly on systems that do not have `xdg-open`, though the src for the crate states that on non-WSL Linux systems, an `xdg-open` script is embedded in the library, thus it may work correctly.